### PR TITLE
financial links: show balance

### DIFF
--- a/app/views/finance/financial_links/show.html.haml
+++ b/app/views/finance/financial_links/show.html.haml
@@ -31,6 +31,34 @@
         %td.numeric{style: 'width:5em'}= format_currency item[:amount]
         %td= link_to t('.remove_from_link'), item[:remove_path], :data => {:confirm => t('.remove_from_link_confirm')}, :method => :delete,
           class: 'btn btn-danger btn-mini'
+  %thead
+    - if @financial_link.bank_transactions.count > 1
+      %tr
+        %th 
+        %th= 'sum of bank transactions:'
+        %th
+        %th.numeric{style: 'width:5em'}= format_currency(@financial_link.bank_transactions.sum(:amount)) 
+        %th
+    - if @financial_link.invoices.count > 1
+      %tr
+        %th 
+        %th= 'sum of invoices:'
+        %th
+        %th.numeric{style: 'width:5em'}= format_currency(@financial_link.invoices.sum(:amount))
+        %th
+    - if @financial_link.financial_transactions.count > 1
+      %tr
+        %th 
+        %th= 'sum of financial transactions:'
+        %th
+        %th.numeric{style: 'width:5em'}= format_currency(@financial_link.financial_transactions.sum(:amount))
+        %th
+    %tr
+      %th 
+      %th= 'total (bank transactions + invoices - financial transactions):'
+      %th
+      %th.numeric{style: 'width:5em'}= format_currency(@financial_link.amount) # total_plus + total_minus)
+      %th
 
 %p
   = @financial_link.note

--- a/app/views/finance/financial_links/show.html.haml
+++ b/app/views/finance/financial_links/show.html.haml
@@ -57,7 +57,7 @@
       %th 
       %th= 'total (bank transactions + invoices - financial transactions):'
       %th
-      %th.numeric{style: 'width:5em'}= format_currency(@financial_link.amount) # total_plus + total_minus)
+      %th.numeric{style: 'width:5em'}= format_currency(@financial_link.amount)
       %th
 
 %p


### PR DESCRIPTION
in complex financial links that link more than two items, it would be useful to see a detailed balance. 
in this PR, a sum of each item category (invoice, bank transaction, foodsoft transaction) is displayed if there is more than one item in the category, and the overall balance is always shown (should be 0).
![grafik](https://github.com/user-attachments/assets/ea35cc48-bbd0-4e24-ba70-0e83c836e662)
