### PR TITLE
fix(grouporder): improves order footer for mobile devices

### DIFF
--- a/app/assets/stylesheets/bootstrap_and_overrides.css.less
+++ b/app/assets/stylesheets/bootstrap_and_overrides.css.less
@@ -235,14 +235,6 @@ table {
   }
 }
 
-/* Hide the orders article info for small screens
-   to prevent the "save order" button to disappear */
-@media only screen and (max-width: 950px) {
-  tr.order-article:hover .article-info {
-    display: none;
-  }
-}
-
 #order-footer {
   width: 100%;
   right: 0;
@@ -279,6 +271,20 @@ tr.order-article:hover .article-info {
   display: block;
 }
 
+/* Hide the orders article info for small screens
+   to prevent the "save order" button to disappear */
+@media only screen and (max-width: 950px) {
+  tr.order-article:hover .article-info {
+    display: none;
+  }
+
+  #order-footer {
+    #total-sum {
+      float: left;
+      margin-left: 2em;
+    }
+  }
+}
 
 // ********* Articles
 


### PR DESCRIPTION
fixes for small devices:

reordered media query for article info to be hidden correctly
aligns order sum + button left

Example URL:
https://app.foodcoops.at/demo/group_orders/81/edit?order_id=109