### PR TITLE
Fix invoice number assignment by removing spaces from content

### DIFF
--- a/app/models/bank_transaction.rb
+++ b/app/models/bank_transaction.rb
@@ -39,7 +39,8 @@ class BankTransaction < ApplicationRecord
 
     content = text || ''
     content += "\n" + reference if reference.present?
-    invoices = supplier.invoices.unpaid.select { |i| content.include? i.number }
+    content.delete!(' ')
+    invoices = supplier.invoices.unpaid.select { |i| content.include? i.number.delete(' ') }
     invoices_sum = invoices.map(&:amount).sum
     return false if amount != -invoices_sum
 


### PR DESCRIPTION
Bei SEPA Banküberweisungen sind bis zu 140 Zeichen im Verwendungszweck möglich. Je nach Bank werden diese Zeichenketten in Einzelfelder zu 35 oder 70 Zeichen aufgeteilt (Vermutlich passiert das bei der Bank, die die Überweisung absendet) und anschließend (von der Empfängerbank?) mit einem Leerzeichen wieder zusammengefügt (das ist in den Bankproxy Implementierungen zwar auch vorgesehen, ist aber in den untersuchten Fällen schon Bank-seitig geschehen).
Wenn nun eine invoice.number genau in diesen Umbruch hineinfällt, wird sie nicht korrekt zugeordnet (z.B. ABCDEFG wird ABCD EFG). Mit diesem Commit werden die Leerzeichen für den Vergleich aus beiden Strings entfernt.