### PR TITLE
Add QR Code links to unpaid invoices

### DIFF
--- a/app/views/finance/invoices/unpaid.html.haml
+++ b/app/views/finance/invoices/unpaid.html.haml
@@ -20,7 +20,12 @@
         = link_to finance_invoice_path(invoice) do
           = format_date invoice.date
           = ' ' + invoice.number
-        = ' ' + number_to_currency(invoice.amount)
+        = ' ' 
+        - if invoice.amount>0 && supplier.iban.present?
+          - url = "https://epc-qr.eu/?#{{iban: supplier.iban, euro: invoice.amount, bname: supplier.name, info: invoice.number}.to_query}"
+          = link_to(number_to_currency(invoice.amount), url)
+        - else
+          = number_to_currency(invoice.amount)
         - if invoice_amount_diff != 0
           %span{style: "color:#{invoice_amount_diff < 0 ? 'red' : 'green'}"}
             = invoice_amount_diff > 0 ? '+' : '-'
@@ -41,7 +46,11 @@
         = invoices_text.join(', ')
         %br/
         %b= t('.invoices_sum') + ':'
-        = number_to_currency invoices_sum
+        - if invoices_sum>0 && supplier.iban.present?
+          - url = "https://epc-qr.eu/?#{{iban: supplier.iban, euro: invoices_sum, bname: supplier.name, info: invoices_text.join(', ')}.to_query}"
+          = link_to number_to_currency(invoices_sum), url      
+        - else 
+          = number_to_currency(invoices_sum)
 
   - if show_pay_button
     = submit_tag t('.pay'), class: 'btn btn-primary'


### PR DESCRIPTION
An URL is added to the amount of individual invoices and to the sum of invoices of each supplier in the unpaid invoices view that leads to a qr-code that can be used in the banking app to pay these invoices.

This supports the transfer of bank payment data from the foodsoft to the banking app if the payment feature is not implemented for a bank proxy or if it is broken.

same as https://github.com/foodcoops/foodsoft/pull/1287