### PR TITLE
Fix privilege escalation via mass assignment in workgroup update (#1323)

### DIFF
--- a/app/controllers/foodcoop/workgroups_controller.rb
+++ b/app/controllers/foodcoop/workgroups_controller.rb
@@ -12,10 +12,16 @@ class Foodcoop::WorkgroupsController < ApplicationController
 
   def update
     @workgroup = Workgroup.find(params[:id])
-    if @workgroup.update(params[:workgroup])
+    if @workgroup.update(workgroup_params)
       redirect_to foodcoop_workgroups_url, notice: I18n.t('workgroups.update.notice')
     else
       render action: 'edit'
     end
+  end
+
+  private
+
+  def workgroup_params
+    params.require(:workgroup).permit(:name, :description, :user_tokens)
   end
 end


### PR DESCRIPTION
Foodcoop::WorkgroupsController#update passed params[:workgroup] straight to update, and the application sets permit_all_parameters = true, so any member of the workgroup (the action only requires membership) could send workgroup[role_admin]=true and grant their group the global admin role, escalating from ordinary member to site administrator.

Restrict the assignment to the fields the member edit form exposes (name, description, user_tokens) with a strong-parameters allowlist, matching the pattern already used in home_controller#update_profile.